### PR TITLE
Release v2.2.4

### DIFF
--- a/pyvariant/core.py
+++ b/pyvariant/core.py
@@ -843,7 +843,6 @@ class Core:
             floor,
             ceiling,
             variant.altseq,
-            insertion=variant.is_insertion,
         )
 
     def _dna_altseq(
@@ -864,7 +863,6 @@ class Core:
             floor,
             ceiling,
             variant.altseq,
-            insertion=variant.is_insertion,
         )
 
     def _exon_altseq(
@@ -895,7 +893,6 @@ class Core:
             floor,
             ceiling,
             variant.altseq,
-            insertion=variant.is_insertion,
         )
 
     def _rna_altseq(
@@ -916,7 +913,6 @@ class Core:
             floor,
             ceiling,
             variant.altseq,
-            insertion=variant.is_insertion,
         )
 
     # ---------------------------------------------------------------------------------------------

--- a/pyvariant/sequence.py
+++ b/pyvariant/sequence.py
@@ -194,8 +194,9 @@ def mutate_sequence(
         window (Optional[int]): Total length of the returned sequence
         floor (Optional[int]): Absolute smallest start position (must be <= `start`)
         ceiling (Optional[int]): Absolute largest end position (must be >= `end`)
-        altseq (str): Alternate allele
-        insertion (bool, optional): True if the mutation is an insertion. Defaults to False.
+        altseq (str): Alternate allele. For insertions, requires the two bases immediately 5' and
+            3' of the insertion site
+        insertion (bool, optional): DEPRECATED
 
     Returns:
         sequence (str): Alternate allele with flanking 5' and 3' bases
@@ -224,12 +225,11 @@ def mutate_sequence(
     del_len = end - start + 1
     ins_len_left = len(altseq) // 2
     ins_len_right = len(altseq) - ins_len_left
-    ins_pad = 1 if insertion else 0
 
-    ref_start = start - pad_left + ins_len_left + ins_pad - 1
+    ref_start = start - pad_left + ins_len_left - 1
     assert ref_start <= start, f"{ref_start} > {start}"
 
-    ref_end = start + pad_right - ins_len_right + del_len - ins_pad - 1
+    ref_end = start + pad_right - ins_len_right + del_len - 1
     assert ref_end >= ref_start, f"{ref_end} < {ref_start}"
 
     # Adjust the reference start if it extends past the start of the molecule (i.e. can't be < 1)
@@ -237,8 +237,8 @@ def mutate_sequence(
         ref_end -= ref_start
         ref_start = 0
 
-    idx_left = start - ref_start + ins_pad - 1
-    idx_right = ref_end - end + ins_pad
+    idx_left = start - ref_start - 1
+    idx_right = ref_end - end
 
     # If the floor is more than ref_start, make the new ref_start equal to floor and pad ref_end by
     # the difference

--- a/pyvariant/sequence.py
+++ b/pyvariant/sequence.py
@@ -196,7 +196,8 @@ def mutate_sequence(
         ceiling (Optional[int]): Absolute largest end position (must be >= `end`)
         altseq (str): Alternate allele. For insertions, requires the two bases immediately 5' and
             3' of the insertion site
-        insertion (bool, optional): DEPRECATED
+        insertion (bool, optional): Deprecated. True if `altseq` should be inserted between `start`
+            and `end`
 
     Returns:
         sequence (str): Alternate allele with flanking 5' and 3' bases
@@ -229,6 +230,9 @@ def mutate_sequence(
     if start > end:
         raise ValueError(f"{start=} > {end=}")
 
+    if insertion and start != end - 1:
+        raise ValueError(f"start must equal end + 1 when insertion is True ({start=} {end=})")
+
     # Catch cases where the given window size is less than the size of the alternate sequence
     if window < len(altseq):
         raise ValueError(
@@ -236,7 +240,7 @@ def mutate_sequence(
         )
 
     # Decrease the effective window size by the number of bases inserted
-    window -= len(altseq)
+    window -= len(altseq) + (2 if insertion else 0)
 
     # If the window size is an odd number, pad the 3' more than the 5' end
     pad_left = window // 2
@@ -244,8 +248,8 @@ def mutate_sequence(
 
     # Get the positions 5' and 3' of the deletion/insertion site within the window
     left_start = start - pad_left
-    left_end = start - 1
-    right_start = end + 1
+    left_end = start - (0 if insertion else 1)
+    right_start = end + (0 if insertion else 1)
     right_end = end + pad_right
 
     # Shift the window 5' or 3' if it would exceed the upper or lower bound

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyvariant
-version = 2.2.3
+version = 2.2.4
 description = Map biological sequence variants (mutations) to their equivalent chromosome, cDNA, gene, exon, protein, and RNA positions.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1066,7 +1066,9 @@ def test_sequence_protein_insertion(ensembl100):
     variant = "ENSP00000282388:p.T187_R188insRND"
     assert ensembl100.sequence(variant) == "TRNDR"
     assert ensembl100.sequence(variant, mutate=False, window=10) == "LRSLTRHPKY"
-    assert ensembl100.sequence(variant, mutate=True, window=10) == "RSLTRNDRHP"
+    assert len(ensembl100.sequence(variant, mutate=False, window=100000)) == 494
+    assert ensembl100.sequence(variant, mutate=True, window=10) == "SLTRNDRHPK"
+    assert len(ensembl100.sequence(variant, mutate=True, window=100000)) == 497
 
 
 # -------------------------------------------------------------------------------------------------

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1061,6 +1061,14 @@ def test_sequence_fusion_minus_plus_read_through(ensembl69):
     )
 
 
+def test_sequence_protein_insertion(ensembl100):
+    # https://github.com/mattdoug604/pyvariant/issues/24
+    variant = "ENSP00000282388:p.T187_R188insRND"
+    assert ensembl100.sequence(variant) == "TRNDR"
+    assert ensembl100.sequence(variant, mutate=False, window=10) == "LRSLTRHPKY"
+    assert ensembl100.sequence(variant, mutate=True, window=10) == "RSLTRNDRHP"
+
+
 # -------------------------------------------------------------------------------------------------
 # normalize_id
 # -------------------------------------------------------------------------------------------------

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -95,55 +95,48 @@ def test_mutate_sequence_dna(
 
 
 @pytest.mark.parametrize(
-    "transcript, start, end, strand, window, floor, ceiling, altseq, insertion, sequence",
+    "transcript, start, end, strand, window, floor, ceiling, altseq, sequence",
     [
         # ENST00000288135:r.7delG
-        ("ENST00000288135", 7, 7, "+", 7, -1, -1, "", False, "CTTGGCG"),
+        ("ENST00000288135", 7, 7, "+", 7, -1, -1, "", "CTTGGCG"),
         # ENST00000288135:r.7_8delGG
-        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "", False, "CTTGCGA"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "", "CTTGCGA"),
         # ENST00000288135:r.7_9delGGG
-        ("ENST00000288135", 7, 9, "+", 7, -1, -1, "", False, "CTTCGAG"),
+        ("ENST00000288135", 7, 9, "+", 7, -1, -1, "", "CTTCGAG"),
         # ENST00000288135:r.7_8insT
-        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "T", True, "TTGTGGC"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "GTG", "TTGTGGC"),
         # ENST00000288135:r.7_8insTT
-        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "TT", True, "TGTTGGC"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "GTTG", "TGTTGGC"),
         # ENST00000288135:r.7_8insTTT
-        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "TTT", True, "TGTTTGG"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "GTTTG", "TGTTTGG"),
         # ENST00000288135:r.7G>C
-        ("ENST00000288135", 7, 7, "+", 7, -1, -1, "C", False, "CTTCGGC"),
+        ("ENST00000288135", 7, 7, "+", 7, -1, -1, "C", "CTTCGGC"),
         # ENST00000288135:r.7_9delGGG
-        ("ENST00000288135", 7, 9, "+", 0, -1, -1, "", False, ""),
+        ("ENST00000288135", 7, 9, "+", 0, -1, -1, "", ""),
         # ENST00000288135:r.7_9delGGG
-        ("ENST00000288135", 7, 9, "+", 1, -1, -1, "", False, "C"),
-        ("ENST00000288135", 7, 9, "+", 7, 7, -1, "", False, "CGAGAGC"),
-        ("ENST00000288135", 7, 9, "+", 6, -1, 9, "", False, "GCACTT"),
+        ("ENST00000288135", 7, 9, "+", 1, -1, -1, "", "C"),
+        ("ENST00000288135", 7, 9, "+", 7, 7, -1, "", "CGAGAGC"),
+        ("ENST00000288135", 7, 9, "+", 6, -1, 9, "", "GCACTT"),
+        # ENST00000288135:r.7_8insTTT
+        ("ENST00000288135", 7, 8, "+", 7, 7, -1, "GTTTG", "GTTTGGC"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, 8, "GTTTG", "TTGTTTG"),
         # ENST00000288135:r.7_8delinsTTT
-        ("ENST00000288135", 7, 8, "+", 7, 7, -1, "TTT", True, "GTTTGGC"),
-        ("ENST00000288135", 7, 8, "+", 7, -1, 8, "TTT", True, "TTGTTTG"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "TTT", "TTTTTGC"),
         # ENST00000288135:r.7G>C
-        ("ENST00000288135", 7, 7, "+", 7, 7, -1, "C", False, "CGGCGAG"),
-        ("ENST00000288135", 7, 7, "+", 7, -1, 7, "C", False, "GCACTTC"),
+        ("ENST00000288135", 7, 7, "+", 7, 7, -1, "C", "CGGCGAG"),
+        ("ENST00000288135", 7, 7, "+", 7, -1, 7, "C", "GCACTTC"),
         # near transcript start
-        ("ENST00000288135", 2, 2, "+", 7, -1, -1, "A", False, "GAACTTG"),
+        ("ENST00000288135", 2, 2, "+", 7, -1, -1, "A", "GAACTTG"),
         # at transcript end
-        ("ENST00000288135", 5147, 5147, "+", 7, -1, -1, "C", False, "AAATCAC"),
+        ("ENST00000288135", 5147, 5147, "+", 7, -1, -1, "C", "AAATCAC"),
     ],
 )
 def test_mutate_sequence_rna(
-    ensembl100, transcript, start, end, strand, window, floor, ceiling, altseq, insertion, sequence
+    ensembl100, transcript, start, end, strand, window, floor, ceiling, altseq, sequence
 ):
     assert (
         mutate_sequence(
-            ensembl100.rna_fasta[0],
-            transcript,
-            start,
-            end,
-            strand,
-            window,
-            floor,
-            ceiling,
-            altseq,
-            insertion=insertion,
+            ensembl100.rna_fasta[0], transcript, start, end, strand, window, floor, ceiling, altseq
         )
         == sequence
     )

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -37,6 +37,7 @@ def test_get_sequence_dna(ensembl100, contig, start, end, strand, window, floor,
 @pytest.mark.parametrize(
     "transcript, start, end, strand, window, floor, ceiling, sequence",
     [
+        # ENST00000288135: 1-GCACTTGGGCGAG...ATATATAAATCAA-5147
         ("ENST00000288135", 7, 9, "+", -1, -1, -1, "GGG"),
         ("ENST00000288135", 7, 9, "+", 3, -1, -1, "GGG"),
         ("ENST00000288135", 7, 9, "+", 6, -1, -1, "TGGGCG"),
@@ -97,6 +98,8 @@ def test_mutate_sequence_dna(
 @pytest.mark.parametrize(
     "transcript, start, end, strand, window, floor, ceiling, altseq, sequence",
     [
+        #                          7-9
+        # ENST00000288135: 1-GCACTTGGGCGAG...ATATATAAATCAA-5147
         # ENST00000288135:r.7delG
         ("ENST00000288135", 7, 7, "+", 7, -1, -1, "", "CTTGGCG"),
         # ENST00000288135:r.7_8delGG

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -96,50 +96,61 @@ def test_mutate_sequence_dna(
 
 
 @pytest.mark.parametrize(
-    "transcript, start, end, strand, window, floor, ceiling, altseq, sequence",
+    "transcript, start, end, strand, window, floor, ceiling, altseq, insertion, sequence",
     [
         #                          7-9
         # ENST00000288135: 1-GCACTTGGGCGAG...ATATATAAATCAA-5147
         # ENST00000288135:r.7delG
-        ("ENST00000288135", 7, 7, "+", 7, -1, -1, "", "CTTGGCG"),
+        ("ENST00000288135", 7, 7, "+", 7, -1, -1, "", False, "CTTGGCG"),
         # ENST00000288135:r.7_8delGG
-        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "", "CTTGCGA"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "", False, "CTTGCGA"),
         # ENST00000288135:r.7_9delGGG
-        ("ENST00000288135", 7, 9, "+", 7, -1, -1, "", "CTTCGAG"),
+        ("ENST00000288135", 7, 9, "+", 7, -1, -1, "", False, "CTTCGAG"),
         # ENST00000288135:r.7_8insT
-        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "GTG", "TTGTGGC"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "GTG", False, "TTGTGGC"),
         # ENST00000288135:r.7_8insTT
-        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "GTTG", "TGTTGGC"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "GTTG", False, "TGTTGGC"),
+        # ENST00000288135:r.7_8insTT
+        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "TT", True, "TGTTGGC"),
         # ENST00000288135:r.7_8insTTT
-        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "GTTTG", "TGTTTGG"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "GTTTG", False, "TGTTTGG"),
         # ENST00000288135:r.7G>C
-        ("ENST00000288135", 7, 7, "+", 7, -1, -1, "C", "CTTCGGC"),
+        ("ENST00000288135", 7, 7, "+", 7, -1, -1, "C", False, "CTTCGGC"),
         # ENST00000288135:r.7_9delGGG
-        ("ENST00000288135", 7, 9, "+", 0, -1, -1, "", ""),
+        ("ENST00000288135", 7, 9, "+", 0, -1, -1, "", False, ""),
         # ENST00000288135:r.7_9delGGG
-        ("ENST00000288135", 7, 9, "+", 1, -1, -1, "", "C"),
-        ("ENST00000288135", 7, 9, "+", 7, 7, -1, "", "CGAGAGC"),
-        ("ENST00000288135", 7, 9, "+", 6, -1, 9, "", "GCACTT"),
+        ("ENST00000288135", 7, 9, "+", 1, -1, -1, "", False, "C"),
+        ("ENST00000288135", 7, 9, "+", 7, 7, -1, "", False, "CGAGAGC"),
+        ("ENST00000288135", 7, 9, "+", 6, -1, 9, "", False, "GCACTT"),
         # ENST00000288135:r.7_8insTTT
-        ("ENST00000288135", 7, 8, "+", 7, 7, -1, "GTTTG", "GTTTGGC"),
-        ("ENST00000288135", 7, 8, "+", 7, -1, 8, "GTTTG", "TTGTTTG"),
+        ("ENST00000288135", 7, 8, "+", 7, 7, -1, "GTTTG", False, "GTTTGGC"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, 8, "GTTTG", False, "TTGTTTG"),
         # ENST00000288135:r.7_8delinsTTT
-        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "TTT", "TTTTTGC"),
+        ("ENST00000288135", 7, 8, "+", 7, -1, -1, "TTT", False, "TTTTTGC"),
         # ENST00000288135:r.7G>C
-        ("ENST00000288135", 7, 7, "+", 7, 7, -1, "C", "CGGCGAG"),
-        ("ENST00000288135", 7, 7, "+", 7, -1, 7, "C", "GCACTTC"),
+        ("ENST00000288135", 7, 7, "+", 7, 7, -1, "C", False, "CGGCGAG"),
+        ("ENST00000288135", 7, 7, "+", 7, -1, 7, "C", False, "GCACTTC"),
         # near transcript start
-        ("ENST00000288135", 2, 2, "+", 7, -1, -1, "A", "GAACTTG"),
+        ("ENST00000288135", 2, 2, "+", 7, -1, -1, "A", False, "GAACTTG"),
         # at transcript end
-        ("ENST00000288135", 5147, 5147, "+", 7, -1, -1, "C", "AAATCAC"),
+        ("ENST00000288135", 5147, 5147, "+", 7, -1, -1, "C", False, "AAATCAC"),
     ],
 )
 def test_mutate_sequence_rna(
-    ensembl100, transcript, start, end, strand, window, floor, ceiling, altseq, sequence
+    ensembl100, transcript, start, end, strand, window, floor, ceiling, altseq, insertion, sequence
 ):
     assert (
         mutate_sequence(
-            ensembl100.rna_fasta[0], transcript, start, end, strand, window, floor, ceiling, altseq
+            ensembl100.rna_fasta[0],
+            transcript,
+            start,
+            end,
+            strand,
+            window,
+            floor,
+            ceiling,
+            altseq,
+            insertion,
         )
         == sequence
     )


### PR DESCRIPTION
Bugfixes:
- Fix the 5' and 3' bases flanking insertions being added twice when `window` is used in the `sequence` method
- Fix negative positions being passed to the sequence fetching method, causing the wrong reference sequence to be returned